### PR TITLE
Allow unsetting LU Cards

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -4,6 +4,12 @@ Alla märkbara ändringar ska dokumenteras i denna fil.
 Baserat på [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 och följer [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.4] - 2023-02-06
+
+### Tillagt
+- `UserApi.updateUser` kan nu ta bort `luCard` ifall man skickar med en empty string
+- Tester för ovan.
+
 ## [1.2.3] - 2022-12-16
 
 ### Ändrat

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ekorre-ts",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ekorre-ts",
-      "version": "1.2.3",
+      "version": "1.2.4",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@esek/auth-server": "5.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ekorre-ts",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "E-Sektionens backend",
   "main": "src/index.ts",
   "scripts": {

--- a/src/api/user.api.ts
+++ b/src/api/user.api.ts
@@ -310,11 +310,6 @@ export class UserAPI {
   }
 
   validLuCard(luCard: string): boolean {
-    // we allow empty LU cards
-    if (luCard === '') {
-      return true;
-    }
-
     // Based on findings about LU cards the first six digits are the same
     // for all cards and the last ten are the card serial
     // https://github.com/esek/ekorre/pull/240#issuecomment-1250354632
@@ -338,7 +333,8 @@ export class UserAPI {
       throw new BadRequestError('Användarnamn kan inte uppdateras');
     }
 
-    if (partial.luCard !== null && !this.validLuCard(partial.luCard ?? '')) {
+    // check if we are trying to update the LU card, and that it's not an empty string or null
+    if ('luCard' in partial && partial.luCard && !this.validLuCard(partial.luCard)) {
       throw new BadRequestError('Ogiltigt LU-kort');
     }
 

--- a/src/api/user.api.ts
+++ b/src/api/user.api.ts
@@ -310,6 +310,11 @@ export class UserAPI {
   }
 
   validLuCard(luCard: string): boolean {
+    // we allow empty LU cards
+    if (luCard === '') {
+      return true;
+    }
+
     // Based on findings about LU cards the first six digits are the same
     // for all cards and the last ten are the card serial
     // https://github.com/esek/ekorre/pull/240#issuecomment-1250354632
@@ -333,7 +338,7 @@ export class UserAPI {
       throw new BadRequestError('Användarnamn kan inte uppdateras');
     }
 
-    if (partial.luCard != null && !this.validLuCard(partial.luCard)) {
+    if (partial.luCard !== null && !this.validLuCard(partial.luCard ?? '')) {
       throw new BadRequestError('Ogiltigt LU-kort');
     }
 

--- a/test/unit/user.api.test.ts
+++ b/test/unit/user.api.test.ts
@@ -192,6 +192,10 @@ test('updating lu card', async () => {
 
   await expect(api.updateUser(mockNewUser1.username, withLuCard)).resolves.not.toThrow();
   await expect(api.getSingleUser(mockNewUser1.username)).resolves.toMatchObject(withLuCard);
+  await expect(api.updateUser(mockNewUser1.username, { ...u })).resolves.not.toThrow();
+
+  // not setting the LU card should not delete it
+  await expect(api.getSingleUser(mockNewUser1.username)).resolves.toMatchObject(withLuCard);
 
   const deleteLuCard = {
     ...u,

--- a/test/unit/user.api.test.ts
+++ b/test/unit/user.api.test.ts
@@ -146,7 +146,7 @@ test('get multiple non-existant users', async () => {
 });
 
 test('updating existing user', async () => {
-  let uu: Partial<PrismaUser> = {
+  const uu: Partial<PrismaUser> = {
     firstName: 'Adolf',
     phone: '1234657890',
     address: 'Kämnärsvägen 22F',
@@ -160,26 +160,46 @@ test('updating existing user', async () => {
   expect(mockNewUser1.username).not.toEqual(uu.username);
 
   await api.updateUser(mockNewUser1.username, uu);
-  let uDbRes = await api.getSingleUser(mockNewUser1.username);
+  const uDbRes = await api.getSingleUser(mockNewUser1.username);
 
   expect(uDbRes).toMatchObject(uu);
+});
 
-  // These should all fail
+test('updating lu card', async () => {
+  const u: Partial<PrismaUser> = {
+    address: 'test',
+    zipCode: 'test',
+    phone: 'test',
+    email: 'testuser@test.se',
+  };
+
+  await api.createUser(mockNewUser1);
+
   await expect(
-    api.updateUser(mockNewUser1.username, { ...uu, luCard: '002504' }),
+    api.updateUser(mockNewUser1.username, { ...u, luCard: '002504' }),
   ).rejects.toThrowError(BadRequestError);
   await expect(
-    api.updateUser(mockNewUser1.username, { ...uu, luCard: '002504000000000A' }),
+    api.updateUser(mockNewUser1.username, { ...u, luCard: '002504000000000A' }),
   ).rejects.toThrowError(BadRequestError);
-  await expect(api.updateUser(mockNewUser1.username, { ...uu, luCard: '00' })).rejects.toThrowError(
+  await expect(api.updateUser(mockNewUser1.username, { ...u, luCard: '00' })).rejects.toThrowError(
     BadRequestError,
   );
 
-  uu = { ...uu, luCard: '0025040000000000' };
-  await expect(api.updateUser(mockNewUser1.username, uu)).resolves.not.toThrow();
+  const withLuCard = {
+    ...u,
+    luCard: '0025040000000000',
+  };
 
-  uDbRes = await api.getSingleUser(mockNewUser1.username);
-  expect(uDbRes).toMatchObject(uu);
+  await expect(api.updateUser(mockNewUser1.username, withLuCard)).resolves.not.toThrow();
+  await expect(api.getSingleUser(mockNewUser1.username)).resolves.toMatchObject(withLuCard);
+
+  const deleteLuCard = {
+    ...u,
+    luCard: '',
+  };
+
+  await expect(api.updateUser(mockNewUser1.username, deleteLuCard)).resolves.not.toThrow();
+  await expect(api.getSingleUser(mockNewUser1.username)).resolves.toMatchObject(deleteLuCard);
 });
 
 test('updating username', async () => {


### PR DESCRIPTION
This allows the user to set an empty string (`''`) as their LU card.
Closes #253