### PR TITLE
[FEAT] Fetch multiple users

### DIFF
--- a/src/api/user.api.ts
+++ b/src/api/user.api.ts
@@ -102,7 +102,7 @@ export class UserAPI {
    * Retrieves multiple users ordered after first name, then last name, and finally class
    * @param usernames Usernames to the users to be received
    */
-  async getMultipleUsers(usernames: string[]): Promise<PrismaUser[]> {
+  async getMultipleUsersOrdered(usernames: string[]): Promise<PrismaUser[]> {
     const u = await prisma.prismaUser.findMany({
       where: {
         username: {
@@ -110,6 +110,30 @@ export class UserAPI {
         },
       },
       orderBy: defaultOrder,
+    });
+
+    return u;
+  }
+
+  /**
+   * Retrieves multiple users ordered in the same order as inputed
+   * @param usernames Usernames to the users to be received
+   */
+  async getMultipleUsersUnordered(usernames: string[]): Promise<PrismaUser[]> {
+    console.log(usernames);
+
+    const u = await prisma.prismaUser.findMany({
+      where: {
+        username: {
+          in: usernames,
+          mode: 'insensitive',
+        },
+      },
+    });
+
+    // Sort the PrismaUser list in the same order as the usernames list
+    u.sort((a, b) => {
+      return usernames.indexOf(a.username) - usernames.indexOf(b.username);
     });
 
     return u;

--- a/src/api/user.api.ts
+++ b/src/api/user.api.ts
@@ -116,24 +116,23 @@ export class UserAPI {
   }
 
   /**
-   * Retrieves multiple users ordered in the same order as inputed
+   * Retrieves multiple users ordered in the same order as inputted
    * @param usernames Usernames to the users to be received
    */
   async getMultipleUsersUnordered(usernames: string[]): Promise<PrismaUser[]> {
-    console.log(usernames);
+    const uns = usernames.map((un) => un.toLowerCase()); // Convert to lowercase before querying and sorting
 
     const u = await prisma.prismaUser.findMany({
       where: {
         username: {
-          in: usernames,
-          mode: 'insensitive',
+          in: uns,
         },
       },
     });
 
     // Sort the PrismaUser list in the same order as the usernames list
     u.sort((a, b) => {
-      return usernames.indexOf(a.username) - usernames.indexOf(b.username);
+      return uns.indexOf(a.username) - uns.indexOf(b.username);
     });
 
     return u;

--- a/src/dataloaders/user.dataloader.ts
+++ b/src/dataloaders/user.dataloader.ts
@@ -24,7 +24,7 @@ export const batchUsersFunction = async (
    * @param usernames
    */
 
-  const apiResponse = await userApi.getMultipleUsers(usernames as string[]);
+  const apiResponse = await userApi.getMultipleUsersOrdered(usernames as string[]);
   if (apiResponse === null)
     return new Array<Error>(usernames.length).fill(new Error('User not found'));
 

--- a/src/models/generated/graphql.ts
+++ b/src/models/generated/graphql.ts
@@ -753,6 +753,7 @@ export type Query = {
   searchUser: Array<User>;
   user: User;
   userByCard: User;
+  users: Array<User>;
   utskott: Utskott;
 };
 
@@ -1027,6 +1028,14 @@ export type QueryUserArgs = {
  */
 export type QueryUserByCardArgs = {
   luCard: Scalars['String'];
+};
+
+/**
+ * Queries and mutations that relies on an election being open
+ * does not take an `electionId` parameter.
+ */
+export type QueryUsersArgs = {
+  usernames: Array<Scalars['String']>;
 };
 
 /**
@@ -2063,6 +2072,12 @@ export type QueryResolvers<
     ParentType,
     ContextType,
     RequireFields<QueryUserByCardArgs, 'luCard'>
+  >;
+  users?: Resolver<
+    Array<ResolversTypes['User']>,
+    ParentType,
+    ContextType,
+    RequireFields<QueryUsersArgs, 'usernames'>
   >;
   utskott?: Resolver<
     ResolversTypes['Utskott'],

--- a/src/resolvers/user.resolver.ts
+++ b/src/resolvers/user.resolver.ts
@@ -123,6 +123,11 @@ const userResolver: Resolvers = {
       const u = await api.getSingleUser(username);
       return reduce(u, userReduce);
     },
+    users: async (_, { usernames }, ctx) => {
+      await hasAuthenticated(ctx);
+      const u = await api.getMultipleUsersUnordered(usernames);
+      return reduce(u, userReduce);
+    },
     userByCard: async (_, { luCard }, ctx) => {
       await hasAuthenticated(ctx);
       const u = await api.getSingleUserByLuCard(luCard);

--- a/src/schemas/user.graphql
+++ b/src/schemas/user.graphql
@@ -6,6 +6,7 @@ scalar Date
 
 type Query {
   user(username: String!): User!
+  users(usernames: [String!]!): [User!]!
   userByCard(luCard: String!): User!
   searchUser(search: String!): [User!]!
   me: User!

--- a/test/unit/user.api.test.ts
+++ b/test/unit/user.api.test.ts
@@ -122,11 +122,22 @@ test('get one user', async () => {
   expect(await api.getSingleUser(mockNewUser0.username)).toMatchObject(expectedResult);
 });
 
-test('get multiple users', async () => {
+test('get multiple users ordered', async () => {
   await api.createUser(mockNewUser1);
-  expect((await api.getMultipleUsers([mockNewUser0.username, mockNewUser1.username])).length).toBe(
-    2,
-  );
+  expect(
+    (await api.getMultipleUsersOrdered([mockNewUser0.username, mockNewUser1.username])).length,
+  ).toBe(2);
+});
+
+test('get multiple users unordered', async () => {
+  await api.createUser(mockNewUser1);
+  const u0 = mockNewUser0.username;
+  const u1 = mockNewUser1.username;
+  const usernames = u1 > u0 ? [u1, u0] : [u0, u1];
+  expect(await api.getMultipleUsersUnordered(usernames)).toEqual([
+    await api.getSingleUser(usernames[0]),
+    await api.getSingleUser(usernames[1]),
+  ]);
 });
 
 test('get all users', async () => {
@@ -141,7 +152,7 @@ test('get non-existat user', async () => {
 
 test('get multiple non-existant users', async () => {
   await expect(
-    api.getMultipleUsers(['fake as shit username', 'and another one here']),
+    api.getMultipleUsersOrdered(['fake as shit username', 'and another one here']),
   ).resolves.toHaveLength(0);
 });
 


### PR DESCRIPTION
Adds a `users` query. A `usernames` list is sent in and a `User` list is returned. Each `User` is in the same order as the corresponding username in the `usernames` list. 

I was not able to get `ctx.userDataLoader.loadMany(usernames)` working in the resolver, so I added a `getMultipleUsersUnordered` method in `user.api.ts` instead. But perhaps the first option could be better as my solution requires sorting the list returned by `prisma.prismaUser.findMany`.

One test case has been added to make sure the returned list is ordered the same way as what was inputted.